### PR TITLE
RFC: reorganisation

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -1,64 +1,77 @@
-- title: Getting Started
-  docs:
-  - index.md
-  - getting-started/architecture.md
-  - getting-started/designs.md
-- title: High-level Features
-  docs:
-  - features/DR/DR.md
-  - features/HA/HA.md
-  - features/XSM/XSM.md
-  - features/RPU/RPU.md
-  - features/VGPU/vgpu.md
-  - features/snapshots/snapshots.md
-- title: XenAPI
-  docs:
-  - xen-api/overview.md
-  - xen-api/usage.md
-  - xen-api/wire-protocol.md
-  - xen-api/evolution.md
-  - xen-api/vm-lifecycle.md
-  - xen-api/snapshots.md
-  - xen-api/importexport.md
-  - xen-api/consoles.md
-  - xen-api/install-vms.md
-  - xen-api/networking.md
-  - xen-api/guest-agents.md
-  - xen-api/metrics.md
-  - xen-api/memory.md
-  - xen-api/xencenter.md
-  - xen-api/udhcp.md
-  - xen-api/index.html
-  - xen-api/releases.html
-- title: Xapi
-  docs:
-  - xapi/overview.md
-  - xapi/architecture.md
-  - xapi/design/memory-accounting.md
-- title: Xenopsd
-  docs:
-  - xenopsd/overview.md
-  - xenopsd/features.md
-  - xenopsd/architecture.md
-  - xenopsd/futures/roadmap.md
-  - xenopsd/design/Events.md
-  - xenopsd/design/Tasks.md
-  - xenopsd/design/hooks.md
-  - xenopsd/design/suspend-image-considerations.md
-  - xenopsd/design/suspend-image-framing-format.md
-  - xenopsd/walkthroughs/VM.start.md
-- title: Squeezed
-  docs:
-  - squeezed/overview.md
-  - squeezed/architecture/architecture.md
-  - squeezed/design/design.md
-- title: Networkd
-  docs:
-  - networkd/overview.md
-- title: Design Docs
-  docs:
-  - design-docs/index.md
-- title: Developer Guide
-  docs:
-  - devguide/howtos/add-field.md
-  - devguide/howtos/add-function.md
+-
+    - title: Welcome
+      docs:
+      - index.md
+-
+    - title: General
+      docs:
+      - xen-api/overview.md
+      - xen-api/wire-protocol.md
+      - xen-api/evolution.md
+      - xen-api/index.html
+      - xen-api/releases.html
+    - title: VM Lifecycle
+      docs:
+      - xen-api/vm-lifecycle.md
+      - xen-api/install-vms.md
+      - xen-api/snapshots.md
+      - xen-api/importexport.md
+    - title: Networking
+      docs:
+      - xen-api/networking.md
+      - xen-api/udhcp.md
+    - title: Other
+      docs:
+      - xen-api/usage.md
+      - xen-api/http.md
+      - xen-api/extensions.md
+      - xen-api/consoles.md
+      - xen-api/guest-agents.md
+      - xen-api/metrics.md
+      - xen-api/memory.md
+      - xen-api/xencenter.md
+-
+    - title: Architecture
+      docs:
+      - getting-started/architecture.md
+      - getting-started/designs.md
+    - title: High-level Features
+      docs:
+      - features/DR/DR.md
+      - features/HA/HA.md
+      - features/XSM/XSM.md
+      - features/RPU/RPU.md
+      - features/VGPU/vgpu.md
+      - features/snapshots/snapshots.md
+    - title: Xapi
+      docs:
+      - xapi/overview.md
+      - xapi/architecture.md
+      - xapi/design/memory-accounting.md
+    - title: Xenopsd
+      docs:
+      - xenopsd/overview.md
+      - xenopsd/features.md
+      - xenopsd/architecture.md
+      - xenopsd/futures/roadmap.md
+      - xenopsd/design/Events.md
+      - xenopsd/design/Tasks.md
+      - xenopsd/design/suspend-image-considerations.md
+      - xenopsd/design/suspend-image-framing-format.md
+      - xenopsd/walkthroughs/VM.start.md
+    - title: Squeezed
+      docs:
+      - squeezed/overview.md
+      - squeezed/architecture/architecture.md
+      - squeezed/design/design.md
+    - title: Networkd
+      docs:
+      - networkd/overview.md
+    - title: Developer Guide
+      docs:
+      - devguide/howtos/add-field.md
+      - devguide/howtos/add-function.md
+-
+    - title: Design Docs
+      docs:
+      - design-docs/index.md

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -36,13 +36,9 @@
         </div>
         <nav>
           <ul class="nav navbar-nav navbar-right">
-            <li>
-              <a href="http://www.xenproject.org/developers/teams/xapi.html">
-                LF project
-              </a>
-            </li>
-            <li><a href="{{site.baseurl}}/">Documentation</a></li>
-            <li><a href="http://github.com/xapi-project">Github</a></li>
+            <li><a href="{{site.baseurl}}/xen-api">XenAPI</a></li>
+            <li><a href="{{site.baseurl}}/getting-started/architecture.html">Architecture</a></li>
+            <li><a href="{{site.baseurl}}/design-docs">Designs</a></li>
           </ul>
         </nav>
       </div>
@@ -52,22 +48,30 @@
         <div class="col-md-3">
         <nav>
           <ul id="menu" class="nav" data-spy="scroll">
-            {% for section in site.data.navbar %}
-              <li>
-                <div class="menu-header">{{section.title}}</div>
-                <ul class="nav">
-                {% for d in section.docs %}
-                  {% for p in site.pages %}
-                    {% if p.path == d %}
-                      <li data-section="{{p.path}}">
-                        <a href="{{site.baseurl}}{{p.url}}">{{p.title}}</a>
-                      </li>
-                    {% endif %}
+          {% for chapter in site.data.navbar %}
+            {% for section in chapter %}
+              {% for d in section.docs %}
+                {% if page.path == d %}
+                  {% for section in chapter %}
+                  <li>
+                    <div class="menu-header">{{section.title}}</div>
+                    <ul class="nav">
+                    {% for d in section.docs %}
+                      {% for p in site.pages %}
+                        {% if p.path == d %}
+                          <li data-section="{{p.path}}">
+                            <a href="{{site.baseurl}}{{p.url}}">{{p.title}}</a>
+                          </li>
+                        {% endif %}
+                      {% endfor %}
+                    {% endfor %}
+                    </ul>
+                  </li>
                   {% endfor %}
-                {% endfor %}
-                </ul>
-              </li>
+                {% endif %}
+              {% endfor %}
             {% endfor %}
+          {% endfor %}
           </ul>
       </nav>
         </div>


### PR DESCRIPTION
Repurpose the top menu bar to divide the information contained in the site into three parts:
- XenAPI user documentation
- Architectural documentation
- Design docs (proposals)

This may make the top menu more useful, and reduces the amount of stuff in the menu on the left.

(just requesting feedback for now... the navbar isn't quite right yet)