### PR TITLE
Add a simple promela model of the queue suspend/resume protocol

### DIFF
--- a/xapi/futures/thin-lvhd/queue.pml
+++ b/xapi/futures/thin-lvhd/queue.pml
@@ -1,0 +1,41 @@
+/* queue suspend/resume protocol */
+
+
+mtype = { data, rst, dunno, one, two }
+
+bool suspend
+bool suspend_ack
+bool inflight_data
+
+proctype consumer(){
+  printf("consumer")
+
+  do
+  :: (inflight_data == true) ->
+    assert (suspend_ack == false);
+    inflight_data = false
+  :: (suspend == false) ->
+    suspend = true;
+    /* ordering important here */
+    (suspend_ack == true);
+    inflight_data = false;
+  :: (suspend == true) ->
+    suspend = false;
+    (suspend_ack == false)
+  od;
+}
+
+proctype producer(){
+  printf("producer")
+  do
+  :: (suspend != suspend_ack) -> suspend_ack = suspend
+  :: ((suspend == false) && (suspend_ack == false)) -> inflight_data = true
+  od
+}
+
+init {
+  atomic {
+    run producer();
+    run consumer();
+  }
+}


### PR DESCRIPTION
In particular we send two kinds of updates

- sync: a full update
- delta: a difference since the last update

We expect a full sync to be send on resume and at no other time.