### PR TITLE
thin-lvhd: xenvmd exports RRDs, not local_allocator

### DIFF
--- a/xapi/futures/thin-lvhd/thin-lvhd.md
+++ b/xapi/futures/thin-lvhd/thin-lvhd.md
@@ -429,7 +429,7 @@ daemon will create the volumes for queues and a volume to represent the
 Monitoring
 ==========
 
-The `local_allocator` process should export RRD datasources over shared
+The `xenvmd` process should export RRD datasources over shared
 memory named
 
 - ```sr_<SR uuid>_<host uuid>_free```: the number of free blocks in


### PR DESCRIPTION
Signed-off-by: Euan Harris <euan.harris@citrix.com>