### PR TITLE
Switch to the Kramdown markdown processor

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-markdown: redcarpet
+markdown: kramdown
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
 highlighter: rouge


### PR DESCRIPTION
Github pages will soon stop supporting redcarpet; see

https://help.github.com/articles/updating-your-markdown-processor-to-kramdown/