### PR TITLE
XenAPI docs: Show implicit messages by default

### DIFF
--- a/assets/css/xenapi.css
+++ b/assets/css/xenapi.css
@@ -115,6 +115,5 @@ th { text-align: left;
 }
 
 .implicit {
-	display: none;
 }
 


### PR DESCRIPTION
They can still be hidden by clicking on "Show/hide implicit".

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>