### PR TITLE
fix html.head.title

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Xapi Project Docs{% if page.title }%} - {{page.title}}{% endif %}</title>
+    <title>Xapi Project Docs{% if page.title %} - {{page.title}}{% endif %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">


### PR DESCRIPTION
error message was:
```
    Liquid Warning: Liquid syntax error (line 5): Unexpected character } in "page.title }" in /_layouts/base.html
```