### PR TITLE
ci: pull xapi definitions nightly

### DIFF
--- a/.github/workflows/pull-xapi-data.yml
+++ b/.github/workflows/pull-xapi-data.yml
@@ -1,0 +1,68 @@
+name: Pull definitions from xen-api (scheduled)
+
+on:
+  schedule:
+    # run nightly to keep docs up-to-date
+    - cron: '33 1 * * *'
+
+jobs:
+  pull-xapi:
+    runs-on: ubuntu-latest
+    env:
+      JEKYLL_DOCDIR: _build/install/default/xapi/doc/jekyll
+
+    steps:
+      - name: Checkout xapi code
+        uses: actions/checkout@v3
+        with:
+          repository: xapi-project/xen-api
+          path: xapi
+          fetch-depth: 256 # hopefully this is enough to pull a tag
+
+      - name: Pull configuration from xs-opam
+        run: |
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+
+      - name: Load environment file
+        id: dotenv
+        uses: falti/dotenv-action@v0.2.8
+
+      - name: Use ocaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          dune-cache: true
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-local-packages: xapi/*.opam
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
+
+      - name: Install dependencies
+        working-directory: xapi
+        run: opam pin list --short | xargs opam install --deps-only --with-test -v
+
+      - name: Generate xapi docs
+        working-directory: xapi
+        run: |
+          opam exec -- ./configure
+          opam exec -- make doc-json
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: web
+
+      - name: Copy files
+        run: cp -r xapi/${{ env.JEKYLL_DOCDIR }}/* web/
+
+      - name: Commit and push changes
+        working-directory: web
+        run: |
+          if git diff --quiet ; then
+            echo "No changes, skipping commit and push step"
+          else
+            hash=$(git --git-dir=../xapi/.git rev-parse HEAD)
+            git config --global user.name 'Github action'
+            git config --global user.email 'github-actions-xapi-project-xapi-github-io[bot]@users.noreply.github.com'
+            git commit -am "deploy: https://github.com/xapi-project/xen-api/commit/$hash"
+            git push
+          fi


### PR DESCRIPTION
Here's a run produced by this workflow, triggered on push (which is not present in this PR):
https://github.com/psafont/xapi-project.github.io/actions/runs/3197316184/jobs/5220366971

The commit produced by the workflow:
https://github.com/xapi-project/xapi-project.github.io/commit/4739c1d9c991cfe567456db650cfaf5b9f82c08d

I'm not sure whether the bot committing the changes will trigger github to publish the docs to the webpage, we can see that tomorrow once the workflow has triggered