### PR TITLE
ci: update actions to supress warnings

### DIFF
--- a/.github/workflows/pull-xapi-data.yml
+++ b/.github/workflows/pull-xapi-data.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v1.0.1
+        uses: falti/dotenv-action@v1
 
       - name: Use ocaml
         uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
The latest dotenv action is v1.0.2. v1 is aliased now to this version and it will be updated if a newer version is released

The warnings can be seen here, they will become errors soon enough: https://github.com/xapi-project/xapi-project.github.io/actions/runs/4050179438