### PR TITLE
Updates to the RRDD protocol design document

### DIFF
--- a/rrdd/design/plugin-protocol-v2.md
+++ b/rrdd/design/plugin-protocol-v2.md
@@ -96,11 +96,11 @@ Protocol V2
 |metadata checksum    |32               |int32 |binary-encoded crc32 of the metadata string (see below)                                 |
 |number of datasources|32               |int32 |only needed if the metadata has changed - otherwise RRDD can use a cached value         |
 |timestamp            |64               |int64 |Unix epoch                                                                              |
-|datasource values    |n * 64           |int64 |n is the number of datasources exported by the plugin                                   |
+|datasource values    |n * 64           |int64 \| double |n is the number of datasources exported by the plugin, type dependent on the setting in the metadata for value_type [int64\|float]  |
 |metadata length      |32               |int32 |                                                                                        |
 |metadata             |(string length)*8|string|                                                                                        |
 
-All integers are bigendian. The metadata will have the same JSON-based format as
+All integers/double are bigendian. The metadata will have the same JSON-based format as
 in the V1 protocol, minus the timestamp and `value` key-value pair for each
 datasource, for example:
 
@@ -124,6 +124,27 @@ datasource, for example:
       "type":"absolute",
       "default":"true",
       "units":"B",
+      "min":"-inf",
+      "max":"inf"
+    },
+    {
+    "cpu-temp-cpu0": {
+      "description": "Temperature of CPU 0",
+      "owner":"host",
+      "value_type": "float",
+      "type": "absolute",
+      "default":"true",
+      "units": "degC",
+      "min":"-inf",
+      "max":"inf"
+    },
+    "cpu-temp-cpu1": {
+      "description": "Temperature of CPU 1",
+      "owner":"host",
+      "value_type": "float",
+      "type": "absolute",
+      "default":"true",
+      "units": "degC",
       "min":"-inf",
       "max":"inf"
     }

--- a/rrdd/design/plugin-protocol-v2.md
+++ b/rrdd/design/plugin-protocol-v2.md
@@ -59,6 +59,7 @@ This should always be present.
 * The JSON data itself, encoding the values and metadata associated with the
 reported datasources.
 
+### Example
 ```
 {
   "timestamp": 1339685573,
@@ -102,8 +103,21 @@ Protocol V2
 
 All integers/double are bigendian. The metadata will have the same JSON-based format as
 in the V1 protocol, minus the timestamp and `value` key-value pair for each
-datasource, for example:
+datasource.
 
+| field | values | notes | required |
+|-------|--------|-------|----------|
+|description|string|Description of the datasource|no|
+|owner|host \| vm \| sr|The object to which the data relates|no, default host|
+|value_type|int64 \| float|The type of the datasource|yes|
+|type|absolute \| derive \| gauge|The type of measurement being sent. Absolute for counters which are reset on reading, derive stores the derivative of the recorded values (useful for metrics which continually increase like amount of data written since start), gauge for things like temperature|no, default absolute|
+|default|true \| false|Whether the source is default enabled or not|no, default false|
+|units|<TBD>|The units the data should be displayed in|no|
+|min||The minimum value for the datasource|no, default -infinity|
+|max||The maximum value for the datasource|no, default +infinity|
+
+
+### Example
 ```
 {
   "datasources": {


### PR DESCRIPTION
This is missing the values of the units field. I think this is somewhat open but dependent on what the consumer can display (e.g. XenCenter)?