### PR TITLE
Fix some obviously out-of-date information about XAPI

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ a sub-project of the Linux Foundation Xen Project.
 ## Getting the Xapi toolstack
 
 The easiest way to use it is to install
-[Citrix Hypervisor Express Edition](https://www.citrix.com/en-gb/downloads/citrix-hypervisor/)
+[XenServer](https://www.xenserver.com/downloads)
 or [XCP-ng](https://xcp-ng.org/#easy-to-install).
 
 Otherwise, you can

--- a/index.md
+++ b/index.md
@@ -31,11 +31,6 @@ The easiest way to use it is to install
 [XenServer](https://www.xenserver.com/downloads)
 or [XCP-ng](https://xcp-ng.org/#easy-to-install).
 
-Otherwise, you can
-
-- follow the [build instructions](https://github.com/xenserver/buildroot)
-- try experimental [ARM packages](http://wiki.xenproject.org/wiki/Running_XCP/xapi_on_ARM)
-
 ## Get in touch
 
 You're welcome to

--- a/index.md
+++ b/index.md
@@ -35,5 +35,4 @@ or [XCP-ng](https://xcp-ng.org/#easy-to-install).
 
 You're welcome to
 
-- join the #xen-api channel on freenode
 - checkout the [code on github](https://github.com/xapi-project/)

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ title: Welcome
 - simplifies maintenance through [Rolling Pool Upgrade](features/RPU/RPU.html)
 - collects performance statistics for historical analysis and for alerting
 - has a full-featured
-  [XML-RPC based API](xen-api/index.html),
+  [XML-RPC and JSON-RPC based API](xen-api/index.html),
   used by clients such as
   [XenCenter](https://github.com/xenserver/xenadmin),
   [Xen Orchestra](https://xen-orchestra.com),


### PR DESCRIPTION
* we recommend JSON-RPC these days, not XML-RPC
* XenServer instead of Citrix Hypervisor
* the XenServer buildroot hasn't been touched in 9 years and can't be used to build any recent release
* ARM packages aren't being worked on
* is the freenode channel in use? I never tried it, but if any of us are on that channel we could keep it

There is obviously more we can do to refresh this page, but we should start by fixing the obviously wrong things.