### PR TITLE
Update Wire Protocol documentation to use Python 3

### DIFF
--- a/xen-api/wire-protocol.md
+++ b/xen-api/wire-protocol.md
@@ -227,11 +227,11 @@ First, initialise python and import the library `xmlrpclib`:
 
     $ python
     ...
-    >>> import xmlrpclib
+    >>> import xmlrpc.client
 
 Create a python object referencing the remote server:
 
-    >>> xen = xmlrpclib.Server("https://localhost:443")
+    >>> xen = xmlrpc.client.Server("https://localhost:443")
 
 Acquire a session reference by logging in with a username and password
 (error-handling ommitted for brevity; the session reference is returned


### PR DESCRIPTION
In the spirit of moving away from Python 2, I spotted its usage in the documentation about the wire protocol. Specifically, `xmlrpclib` has been factored into `xmlrpc.client` and `xmlrpc.server` in Python 3.