### PR TITLE
CI: copy docs build location, not the install location

### DIFF
--- a/.github/workflows/pull-xapi-data.yml
+++ b/.github/workflows/pull-xapi-data.yml
@@ -9,7 +9,7 @@ jobs:
   pull-xapi:
     runs-on: ubuntu-latest
     env:
-      JEKYLL_DOCDIR: _build/install/default/share/jekyll
+      JEKYLL_DOCDIR: _build/default/ocaml/doc/jekyll
 
     steps:
       - name: Checkout xapi code


### PR DESCRIPTION
The CI doesn't install these, only builds them so pick their location accordingly